### PR TITLE
fix : 채팅방 메시지 읽지 않음 버그 수정

### DIFF
--- a/src/main/java/com/mercury/star_be/chat/controller/ChatController.java
+++ b/src/main/java/com/mercury/star_be/chat/controller/ChatController.java
@@ -113,12 +113,13 @@ public class ChatController {
     /**채팅방 내 메시지 읽음 udpate 컨트롤러*/
     @MessageMapping("/readCheck/{chatRoomId}")
     @SendTo("/topic/readCheck.{chatRoomId}")
-    public void updateReadUsers(
+    public ApiResponse<ChatReadResponse> updateReadUsers(
             @DestinationVariable
             Long chatRoomId,
             @Payload ChatReadRequest chatReadRequest
     ){
-        chatService.updateReadCount(chatReadRequest, chatRoomId);
+        ChatReadResponse response = chatService.updateReadCount(chatReadRequest, chatRoomId);
+        return ApiResponse.success(response);
     }
     /**현재 접속한 사용자 반환*/
     @MessageMapping("/chat/connect/{chatRoomId}")

--- a/src/main/java/com/mercury/star_be/chat/entity/ChatMessage.java
+++ b/src/main/java/com/mercury/star_be/chat/entity/ChatMessage.java
@@ -2,6 +2,7 @@ package com.mercury.star_be.chat.entity;
 
 import com.mercury.star_be.user.entity.User;
 import jakarta.persistence.*;
+import jakarta.transaction.Transactional;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;

--- a/src/main/java/com/mercury/star_be/chat/repository/ChatMessageRepository.java
+++ b/src/main/java/com/mercury/star_be/chat/repository/ChatMessageRepository.java
@@ -1,12 +1,19 @@
 package com.mercury.star_be.chat.repository;
 
 import com.mercury.star_be.chat.entity.ChatMessage;
+import io.lettuce.core.dynamic.annotation.Param;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
 import java.util.Optional;
 
 public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> {
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT cm FROM ChatMessage cm WHERE cm.id = :chatMessageId")
+    Optional<ChatMessage> findByIdWithLock(@Param("chatMessageId") Long chatMessageId);
     //채팅 메시지 목록을 가져오기
     Optional<List<ChatMessage>> findByChatRoomId(Long chatRoomId);
     // 가장 최신의 채팅 메시지 하나를 가져오기

--- a/src/main/java/com/mercury/star_be/chat/service/ChatService.java
+++ b/src/main/java/com/mercury/star_be/chat/service/ChatService.java
@@ -39,7 +39,7 @@ public interface ChatService {
     //채팅방 id를 받아 List<ChatRoomMemberDto>로 return
     List<ChatRoomMemberDto> getChatRoomMembers(ChatRoom chatRoom);
     //읽음 update
-    void updateReadCount(ChatReadRequest chatReadRequest, Long chatRoomId);
+    ChatReadResponse updateReadCount(ChatReadRequest chatReadRequest, Long chatRoomId);
     //사용자가 채팅방에서 읽지 않은 메시지들의 아이디 리스트
     List<Long> findUnreadMessageIds(Long chatRoomId, Long userId);
     //읽지 않은 메시지들의 아이디 리스트를 받아  메시지 읽음 테이블에 insert / 메시지 테이블에 update

--- a/src/main/java/com/mercury/star_be/chat/service/ChatServiceImpl.java
+++ b/src/main/java/com/mercury/star_be/chat/service/ChatServiceImpl.java
@@ -24,6 +24,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.amqp.AmqpException;
 import org.springframework.amqp.rabbit.core.RabbitMessagingTemplate;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.retry.annotation.Backoff;
+import org.springframework.retry.annotation.Retryable;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 
@@ -641,26 +643,46 @@ public class ChatServiceImpl implements ChatService {
 
         return chatRoomMembers;
     }
-    
+
     /**
      * 채팅메시지 읽음 update 서비스
-     * RabbitMQListener
      * */
     @Override
     @Transactional
-    public void updateReadCount(ChatReadRequest chatReadRequest, Long chatRoomId) {
-        // 메시지 읽음 처리 요청을 큐에 추가
-        try {
-            String messageJson = objectMapper.writeValueAsString(chatReadRequest);
-            messagingTemplate
-                    .convertAndSend("readCheck.exchange", "readCheck.request." + chatRoomId, messageJson);
-        } catch (JsonProcessingException e) {
-            e.printStackTrace();
-            throw new BusinessException(ChatErrorCode.CHAT_MESSAGE_CONVERT_ERROR);
-        } catch (AmqpException e) {
-            e.printStackTrace();
-            throw new BusinessException(ChatErrorCode.MESSAGE_SENDING_ERROR);
+    public ChatReadResponse updateReadCount(ChatReadRequest chatReadRequest, Long chatRoomId) {
+
+        //특정 유저가 채팅메시지를 읽었는지 확인
+        boolean isRead = chatReadRepository.
+                existsByChatMessageIdAndChatUserId(chatReadRequest.getChatMessageId(), chatReadRequest.getChatUserId());
+        //이미 읽었었다면 end
+        if (isRead) {
+            throw new BusinessException(ChatErrorCode.CHAT_ALREADY_READ);
         }
+
+        ChatMessage chatMessage = chatMessageRepository.findByIdWithLock(chatReadRequest.getChatMessageId()).orElseThrow(
+                () -> new BusinessException(ChatErrorCode.CHAT_MESSAGE_NOT_FOUND)
+        );
+
+        if (chatMessage.getUnreadCount() > 0) {
+            chatMessage.updateUnreadCount(chatMessage.getUnreadCount() - 1);
+        }
+
+        User chatUser = userRepository.findById(chatReadRequest.getChatUserId()).orElseThrow(() -> new BusinessException(UserErrorCode.USER_NOT_EXIST));
+        ChatRead chatRead = ChatRead.builder()
+                .chatUser(chatUser)
+                .chatMessage(chatMessage)
+                .createdAt(LocalDateTime.now())
+                .build();
+
+        chatReadRepository.save(chatRead);
+
+        System.out.println("읽음 업데이트 되었습니다. 메시지 ID " + chatReadRequest.getChatMessageId() + "읽음 카운트 :"+chatMessage.getUnreadCount());
+
+        ChatReadResponse response = ChatReadResponse.builder()
+                .chatMessageId(chatMessage.getId())
+                .unreadCount(chatMessage.getUnreadCount())
+                .build();
+        return response;
     }
 
     @Override

--- a/src/main/java/com/mercury/star_be/global/error/code/ChatErrorCode.java
+++ b/src/main/java/com/mercury/star_be/global/error/code/ChatErrorCode.java
@@ -13,7 +13,7 @@ public enum ChatErrorCode implements ErrorCode {
     USER_CHAT_ROOM_NOT_FOUND(HttpStatus.NOT_FOUND, "사용자 채팅방을 찾을 수 없습니다."),
     CHAT_MESSAGE_CONVERT_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "메시지 변환이 올바르게 적용되지 않았습니다."),
     MESSAGE_SENDING_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "RabbitMQ로 메시지를 전달하지 못했습니다."),
-    CHAT_UNREADCOUNT_NOT_UPDATED(HttpStatus.INTERNAL_SERVER_ERROR, "RabbitMQ로 메시지 읽은 사람을 수정 / 전달하지 못했습니다."),
+    CHAT_UNREADCOUNT_NOT_UPDATED(HttpStatus.INTERNAL_SERVER_ERROR, "메시지 읽음 상태가 UPDATE되지 못했습니다."),
     CHAT_ALREADY_READ(HttpStatus.BAD_REQUEST, "이미 읽음표시 되었습니다."),
     CHAT_ROOM_CONNECTED_MEMBER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "접속중인 사용자 정보를 가져올 수 없습니다");
     private final HttpStatus httpStatus;


### PR DESCRIPTION
## What is this PR? 👓
채팅창에서 읽음 처리 요청을 보낼 때, 채팅메시지를 찾는 부분에 비관적 락 적용. 한 요청이 끝날 때까지 다른 요청에 의한 DB data 접근 방지.

## To reviewers 👋
