### PR TITLE
feat/#112 rabbitmq를 사용한 sse 다중서버 처리

### DIFF
--- a/src/main/java/com/mercury/star_be/chat/controller/ChatController.java
+++ b/src/main/java/com/mercury/star_be/chat/controller/ChatController.java
@@ -19,6 +19,7 @@ import org.springframework.web.bind.annotation.*;
 public class ChatController {
 
     private final ChatService chatService;
+
     /**
      * 채팅방 조회 컨트롤러
      * */
@@ -267,9 +268,4 @@ public class ChatController {
         boolean isReadCheck = chatService.isReadCheck(chatReadRequest);
         return ApiResponse.success(isReadCheck);
     }
-
-    //사용자 차단
-    //사용자 차단 해제
-    //차단 사용자 목록
-
 }

--- a/src/main/java/com/mercury/star_be/global/config/RabbitMQConfig.java
+++ b/src/main/java/com/mercury/star_be/global/config/RabbitMQConfig.java
@@ -53,6 +53,11 @@ public class RabbitMQConfig {
     private static final String TIMER_EXCHANGE_NAME = "groups.exchange";
     private static final String TIMER_ROUTING_KEY = "groups.#";
 
+    // SSE
+    public static final String SSE_EXCHANGE_NAME = "sse.exchange";
+    private static final String SSE_QUEUE_NAME = "sse.queue.";
+
+
     //Queue 등록
     @Bean
     public Queue chatQueue() {
@@ -97,6 +102,16 @@ public class RabbitMQConfig {
         return new Queue(TIMER_QUEUE_NAME,true);
     }
 
+    // SSE Queue 등록
+    @Bean
+    public Queue sseQueue() {
+        String instanceName = System.getenv("INSTANCE_NAME");
+        if (instanceName == null) {
+            instanceName = "local";
+        }
+        return new Queue(SSE_QUEUE_NAME + instanceName, true);
+    }
+
     //Exchange 등록
     @Bean
     public TopicExchange exchange(){ return new TopicExchange(CHAT_EXCHANGE_NAME); }
@@ -107,6 +122,12 @@ public class RabbitMQConfig {
     @Bean
     public TopicExchange timerExchange() {
         return new TopicExchange(TIMER_EXCHANGE_NAME);
+    }
+
+    // SSE Exchange 등록
+    @Bean
+    public FanoutExchange sseExchange() {
+        return new FanoutExchange(SSE_EXCHANGE_NAME);
     }
 
     //Exchange와 Queue 바인딩
@@ -130,6 +151,7 @@ public class RabbitMQConfig {
     public Binding readCheckResponseBinding(Queue readCheckResponseQueue, TopicExchange readCheckExchange) {
         return BindingBuilder.bind(readCheckResponseQueue).to(readCheckExchange).with(READ_CHECK_RESPONSE_ROUTING_KEY);
     }
+
     // Timer Exchange와 Queue 바인딩
     @Bean
     public Binding timerBinding(Queue timerQueue, TopicExchange timerExchange) {
@@ -142,6 +164,12 @@ public class RabbitMQConfig {
     @Bean
     public Binding chatDisconnectBinding(Queue chatDisconnectQueue, TopicExchange exchange) {
         return BindingBuilder.bind(chatDisconnectQueue).to(exchange).with(CHAT_DISCONNECT_ROUTING_KEY);
+    }
+
+    // SSE Exchange와 Queue 바인딩
+    @Bean
+    public Binding statusBinding(Queue sseQueue, FanoutExchange sseExchange) {
+        return BindingBuilder.bind(sseQueue).to(sseExchange);
     }
 
     /* messageConverter를 커스터마이징 하기 위해 Bean 새로 등록 */

--- a/src/main/java/com/mercury/star_be/global/error/code/StudyGroupErrorCode.java
+++ b/src/main/java/com/mercury/star_be/global/error/code/StudyGroupErrorCode.java
@@ -17,7 +17,11 @@ public enum StudyGroupErrorCode implements ErrorCode {
 	USER_NOT_HOST(HttpStatus.UNAUTHORIZED, "그룹장 권한이 없습니다."),
 	STUDY_GROUP_IS_EMPTY(HttpStatus.CONFLICT, "스터디 그룹에 유저가 없습니다."),
 	INVALID_GROUP_PASSWORD(HttpStatus.UNAUTHORIZED, "비밀번호가 일치하지 않습니다"),
-	INVALID_MAX_CAPACITY(HttpStatus.BAD_REQUEST, "최대 인원이 현재 인원보다 작을 수 없습니다.");
+	INVALID_MAX_CAPACITY(HttpStatus.BAD_REQUEST, "최대 인원이 현재 인원보다 작을 수 없습니다."),
+
+	// SSE 관련 에러
+	SSE_EMITTER_IO_EXCEPTION(HttpStatus.INTERNAL_SERVER_ERROR, "서버에서 SSE 메시지를 보내는 중 오류가 발생했습니다.")
+	;
 
 	private final HttpStatus httpStatus;
 	private final String message;

--- a/src/main/java/com/mercury/star_be/studygroup/dto/SseQueueMessage.java
+++ b/src/main/java/com/mercury/star_be/studygroup/dto/SseQueueMessage.java
@@ -1,0 +1,15 @@
+package com.mercury.star_be.studygroup.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class SseQueueMessage {
+
+	private Long groupId;
+	private String eventName;
+	private Object data;
+}

--- a/src/main/java/com/mercury/star_be/studygroup/repository/SseEmitterRepository.java
+++ b/src/main/java/com/mercury/star_be/studygroup/repository/SseEmitterRepository.java
@@ -9,6 +9,8 @@ import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Repository;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
+import com.mercury.star_be.global.error.BusinessException;
+import com.mercury.star_be.global.error.code.StudyGroupErrorCode;
 import com.mercury.star_be.studygroup.entity.ConnectionStatus;
 
 import lombok.RequiredArgsConstructor;
@@ -75,7 +77,7 @@ public class SseEmitterRepository {
 						.name("heartbeat")
 						.data("ping"));
 				} catch (IOException e) {
-					emitter.complete();
+					throw new BusinessException(StudyGroupErrorCode.SSE_EMITTER_IO_EXCEPTION);
 				}
 			}
 		}

--- a/src/main/java/com/mercury/star_be/studygroup/service/SseRabbitMQListener.java
+++ b/src/main/java/com/mercury/star_be/studygroup/service/SseRabbitMQListener.java
@@ -1,0 +1,24 @@
+package com.mercury.star_be.studygroup.service;
+
+import org.springframework.amqp.rabbit.annotation.RabbitListener;
+import org.springframework.stereotype.Component;
+
+import com.mercury.star_be.studygroup.dto.SseQueueMessage;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class SseRabbitMQListener {
+
+	private final StudyGroupSseService studyGroupSseService;
+
+	/**
+	 * sse 큐에서 메시지를 가져와 그룹에 연결된 사용자에게 전송
+	 * 서버마다 큐 이름이 다르기 때문에 #{sseQueue.name}으로 가져옴
+	 */
+	@RabbitListener(queues = "#{sseQueue.name}")
+	public void receiveSseMessage(SseQueueMessage message) {
+		studyGroupSseService.sendToGroup(message.getGroupId(), message.getEventName(), message.getData());
+	}
+}

--- a/src/main/java/com/mercury/star_be/studygroup/service/StudyGroupSseService.java
+++ b/src/main/java/com/mercury/star_be/studygroup/service/StudyGroupSseService.java
@@ -15,4 +15,6 @@ public interface StudyGroupSseService {
 	void sendMemberStatusToGroup(Long groupId, Long userId, ConnectionStatus status);
 
 	void sendGroupMemberInfoToGroup(Long groupId);
+
+	void sendToGroup(Long groupId, String eventName, Object data);
 }

--- a/src/main/java/com/mercury/star_be/studygroup/service/StudyGroupSseServiceImpl.java
+++ b/src/main/java/com/mercury/star_be/studygroup/service/StudyGroupSseServiceImpl.java
@@ -1,10 +1,13 @@
 package com.mercury.star_be.studygroup.service;
 
+import static com.mercury.star_be.global.config.RabbitMQConfig.*;
+
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
@@ -13,6 +16,7 @@ import com.mercury.star_be.chat.repository.ChatRoomRepository;
 import com.mercury.star_be.global.error.BusinessException;
 import com.mercury.star_be.global.error.code.ChatErrorCode;
 import com.mercury.star_be.studygroup.dto.GroupMemberDto;
+import com.mercury.star_be.studygroup.dto.SseQueueMessage;
 import com.mercury.star_be.studygroup.dto.response.GroupMemberSseResponse;
 import com.mercury.star_be.studygroup.dto.response.MemberStatusSseResponse;
 import com.mercury.star_be.studygroup.entity.ConnectionStatus;
@@ -28,6 +32,7 @@ public class StudyGroupSseServiceImpl implements StudyGroupSseService {
 	private final SseEmitterRepository sseEmitterRepository;
 	private final GroupMemberRepository groupMemberRepository;
 	private final ChatRoomRepository chatRoomRepository;
+	private final RabbitTemplate rabbitTemplate;
 
 	private static final Long SSE_TIMEOUT = 60 * 60 * 1000L;	// 1시간
 	private static final String CONNECT_EVENT = "connect";
@@ -75,7 +80,8 @@ public class StudyGroupSseServiceImpl implements StudyGroupSseService {
 			.userId(userId)
 			.status(ConnectionStatus.OFFLINE)
 			.build();
-		sendToGroup(groupId, STATUS_UPDATE_EVENT, memberStatusSseResponse);
+		SseQueueMessage message = new SseQueueMessage(groupId, STATUS_UPDATE_EVENT, memberStatusSseResponse);
+		rabbitTemplate.convertAndSend(SSE_EXCHANGE_NAME, "", message);
 	}
 
 	private void sendGroupMemberInfoList(Long groupId, SseEmitter sseEmitter) {
@@ -106,20 +112,22 @@ public class StudyGroupSseServiceImpl implements StudyGroupSseService {
 
 	@Override
 	public void sendFocusRoomMemberCountToGroup(Long groupId, int memberCount) {
-		sendToGroup(groupId, FOCUS_ROOM_MEMBER_COUNT_EVENT, memberCount);
+		SseQueueMessage message = new SseQueueMessage(groupId, FOCUS_ROOM_MEMBER_COUNT_EVENT, memberCount);
+		rabbitTemplate.convertAndSend(SSE_EXCHANGE_NAME, "", message);
 	}
 
-	public void sendFocusRoomMemberCount(Long groupId, SseEmitter sseEmitter) {
+	private void sendFocusRoomMemberCount(Long groupId, SseEmitter sseEmitter) {
 		int focusRoomMemberCount = sseEmitterRepository.getFocusRoomMemberCount(groupId);
 		sendData(sseEmitter, FOCUS_ROOM_MEMBER_COUNT_EVENT, focusRoomMemberCount);
 	}
 
 	@Override
 	public void sendChatRoomMemberCountToGroup(Long groupId, int memberCount) {
-		sendToGroup(groupId, CHAT_ROOM_MEMBER_COUNT_EVENT, memberCount);
+		SseQueueMessage message = new SseQueueMessage(groupId, CHAT_ROOM_MEMBER_COUNT_EVENT, memberCount);
+		rabbitTemplate.convertAndSend(SSE_EXCHANGE_NAME, "", message);
 	}
 
-	public void sendChatRoomMemberCount(Long groupId, SseEmitter sseEmitter) {
+	private void sendChatRoomMemberCount(Long groupId, SseEmitter sseEmitter) {
 		ChatRoom chatRoom = chatRoomRepository.findByStudyGroupId(groupId)
 			.orElseThrow(() -> new BusinessException(ChatErrorCode.CHAT_ROOM_NOT_FOUND));
 		int chatRoomMemberCount = sseEmitterRepository.getChatRoomMemberCount(chatRoom.getId());
@@ -133,16 +141,19 @@ public class StudyGroupSseServiceImpl implements StudyGroupSseService {
 			.userId(userId)
 			.status(status)
 			.build();
-		sendToGroup(groupId, STATUS_UPDATE_EVENT, memberStatusSseResponse);
+		SseQueueMessage message = new SseQueueMessage(groupId, STATUS_UPDATE_EVENT, memberStatusSseResponse);
+		rabbitTemplate.convertAndSend(SSE_EXCHANGE_NAME, "", message);
 	}
 
 	@Override
 	public void sendGroupMemberInfoToGroup(Long groupId) {
 		List<GroupMemberSseResponse> groupMemberInfoList = getGroupMemberInfoList(groupId);
-		sendToGroup(groupId, MEMBER_DATA_EVENT, groupMemberInfoList);
+		SseQueueMessage message = new SseQueueMessage(groupId, MEMBER_DATA_EVENT, groupMemberInfoList);
+		rabbitTemplate.convertAndSend(SSE_EXCHANGE_NAME, "", message);
 	}
 
-	private void sendToGroup(Long groupId, String eventName, Object data) {
+	@Override
+	public void sendToGroup(Long groupId, String eventName, Object data) {
 		Map<Long, SseEmitter> groupSseEmitters = sseEmitterRepository.findAllByGroupId(groupId);
 		groupSseEmitters.forEach((userId, sseEmitter) -> {
 			if (sseEmitter != null) {


### PR DESCRIPTION
## What is this PR? 👓
- rabbitmq를 사용해서 sse 메시지를 전송하도록 변경
- 서버마다 하나의 큐를 생성하도록 설정
    - gcp에 instance_name 환경변수를 설정해줘야함